### PR TITLE
Add closure for handling page change

### DIFF
--- a/Source/PagesController.swift
+++ b/Source/PagesController.swift
@@ -174,7 +174,7 @@ extension PagesController : UIPageViewControllerDelegate {
 
 extension PagesController {
 
-  func setViewController(viewController: UIViewController, atPage page:Int) {
+  private func setViewController(viewController: UIViewController, atPage page:Int) {
     pagesDelegate?.pageViewController(self,
       setViewController: viewController,
       atPage: page)

--- a/Source/PagesController.swift
+++ b/Source/PagesController.swift
@@ -178,9 +178,7 @@ extension PagesController {
     pagesDelegate?.pageViewController(self,
       setViewController: viewController,
       atPage: page)
-    if let pageChangeHandler = pageChangeHandler {
-      pageChangeHandler(viewController: viewController, page: page)
-    }
+    pageChangeHandler?(viewController: viewController, page: page)
   }
 
   func viewControllerIndex(viewController: UIViewController) -> Int? {

--- a/Source/PagesController.swift
+++ b/Source/PagesController.swift
@@ -38,6 +38,8 @@ import UIKit
 
   public var pagesDelegate: PagesControllerDelegate?
 
+  public var pageChangeHandler: ((viewController: UIViewController, page: Int) -> Void)?
+
   public private(set) lazy var bottomLineView: UIView = {
     let view = UIView()
     view.setTranslatesAutoresizingMaskIntoConstraints(false)
@@ -95,9 +97,9 @@ extension PagesController {
         direction: direction,
         animated: true,
         completion: { [unowned self] finished in
-          self.pagesDelegate?.pageViewController(self,
-            setViewController: viewController,
-            atPage: self.currentIndex)
+          if finished {
+            self.setViewController(viewController, atPage: self.currentIndex)
+          }
         })
       if setNavigationTitle {
         title = viewController.title
@@ -162,7 +164,7 @@ extension PagesController : UIPageViewControllerDelegate {
             pageControl.currentPage = currentIndex
           }
 
-          pagesDelegate?.pageViewController(self, setViewController: pages[currentIndex], atPage: currentIndex)
+          setViewController(pages[currentIndex], atPage: currentIndex)
       }
     }
   }
@@ -171,6 +173,15 @@ extension PagesController : UIPageViewControllerDelegate {
 // MARK: Private methods
 
 extension PagesController {
+
+  func setViewController(viewController: UIViewController, atPage page:Int) {
+    pagesDelegate?.pageViewController(self,
+      setViewController: viewController,
+      atPage: page)
+    if let pageChangeHandler = pageChangeHandler {
+      pageChangeHandler(viewController: viewController, page: page)
+    }
+  }
 
   func viewControllerIndex(viewController: UIViewController) -> Int? {
     return find(pages, viewController)
@@ -190,9 +201,9 @@ extension PagesController {
         direction: .Forward,
         animated: true,
         completion: { [unowned self] finished in
-          self.pagesDelegate?.pageViewController(self,
-            setViewController: viewController,
-            atPage: self.currentIndex)
+          if finished {
+            self.setViewController(viewController, atPage: self.currentIndex)
+          }
         })
       if setNavigationTitle {
         title = viewController.title


### PR DESCRIPTION
We need to handle page change in subclasses (like `PresentationController`), but it's not good to occupy `pagesDelegate` which could be needed during the actual usage.
